### PR TITLE
support hashes in the URL to identify puppies

### DIFF
--- a/application.js
+++ b/application.js
@@ -4,6 +4,11 @@ $(document).ready(function() {
 
 function playPuppies(puppies) {
     var lastPuppy;
+    var keycodes = {
+        spacebar: 32,
+        left_arrow: 37,
+        right_arrow: 39
+    }
 
     function pickUpPuppy() {
       var puppyCount = puppies.length;
@@ -12,41 +17,43 @@ function playPuppies(puppies) {
 
 
     function newPuppy() {
-        if (lastPuppy) {
+        var newPup = pickUpPuppy();
+        while (lastPuppy == newPup) {
             var newPup = pickUpPuppy();
-            while (lastPuppy == newPup) {
-                var newPup = pickUpPuppy();
-            }
-
-            lastPuppy = newPup;
-            return 'http://i.imgur.com/' + newPup + '.mp4';
-        } else {
-            var pup = pickUpPuppy();
-
-            lastPuppy = pup;
-            return 'http://i.imgur.com/' + pup + '.mp4';
         }
+
+        lastPuppy = newPup;
+        return newPup;
     }
 
-    function loadPuppy() {
-        var newPup = newPuppy();
-        $('#puppy > source').attr('src', newPup);
-        $('.permalink a').attr('href', newPup);
-        // console.log($('#puppy > source').attr('src'));
-        $('.permalink').load();
+    function makeURL(newPup) {
+        return 'http://i.imgur.com/' + newPup + '.mp4';
+    }
+
+    function loadPuppy(newPup) {
+        var url = makeURL(newPup);
+        $('#puppy > source').attr('src', url);
+        $('.permalink a').attr('href', url);
         $('#puppy').load();
+        history.pushState({pup: newPup}, '', '#' + newPup);
     }
 
-    function loadNewPuppy() {
-        var spacebar = 32;
+    $(document).keyup(function(evt) {
+        if (evt.keyCode == keycodes.spacebar || evt.keyCode == keycodes.right_arrow) { // right arrow should probably go forward, but not sure how to know we're at the end of the history stack
+            var newPup = newPuppy();
+            loadPuppy(newPup);
+        } else if (evt.keyCode == keycodes.left_arrow) {
+            history.back();
+        }
+    });
 
-        $(document).keyup(function(evt) {
-            if (evt.keyCode == spacebar) {
-                loadPuppy();
-            }
-        });
+    window.addEventListener('popstate', function(e) {
+        loadPuppy(e.state.pup);
+    })
+
+    var initial_pup = window.location.hash.substring(1);
+    if (puppies.indexOf(initial_pup) == -1) {
+        initial_pup = newPuppy();
     }
-
-    loadPuppy();
-    loadNewPuppy();
+    loadPuppy(initial_pup);
 }


### PR DESCRIPTION
this makes it so that you can share URLs and come back to the site to see the picture that was visible when the URL was shared (assuming that the puppy ID is still in the `puppies.json`)

and a couple of minor refactorings along the way...

looks like there's a little bug in the back implementation, but i'll leave that as an exercise for someone ;)
