### PR TITLE
Inform user of the spacebar if they try to reload

### DIFF
--- a/application.js
+++ b/application.js
@@ -121,6 +121,11 @@ function playPuppies(puppies) {
         }
     });
 
+    // If the user tries reloading to find a new puppy, inform them of the spacebar
+    $(window).bind('beforeunload', function() {
+        return "To see a new puppy, hit the spacebar instead of reloading";
+    });
+
     window.addEventListener('popstate', function(e) {
         if (e.state && e.state.pup) {
             showPuppy(e.state.pup);


### PR DESCRIPTION
Ideally we'd be able to override to reload action altogether and instead just `loadPuppy()`, but AFAICT reload-overriding is forbidden on modern browsers for security/UX reasons.
