### PR TITLE
Make it easier to get back to puppies after using the adoption form

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,9 +31,9 @@
                 <br>
                 Put in your ZIP code to find nearby shelters!
             </p>
-            <form id="adoptionForm" class="adoptionText" action="https://www.petfinder.com/animal-shelters-and-rescues/search/" method="GET" autocomplete="off" novalidate>
+            <form id="adoptionForm" class="adoptionText" action="https://www.petfinder.com/animal-shelters-and-rescues/search/" method="GET" autocomplete="off" target="_blank">
                 <input class="adoptionText" type="text" onkeypress="return (event.charCode == 13 || (event.charCode > 47 && event.charCode < 58));" name="location" id="location">
-                <input class="adoptionText adoptionButton" type="submit" value="Search!">
+                <input class="adoptionText adoptionButton" type="submit" value="Search!" onclick='document.getElementById("adoptionInfo").style.visibility = "hidden";'>
                 <button class="adoptionText adoptionButton" type="button" onclick='document.getElementById("adoptionInfo").style.visibility = "hidden";'>No thanks…</button>
             </form>
         </div>


### PR DESCRIPTION
Petfinder should open in a new window, so that the user can always go back to Open Puppies. Also, hide the form once it's submitted.
